### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/recategorize-discussions.yml
+++ b/.github/workflows/recategorize-discussions.yml
@@ -1,6 +1,9 @@
 # This is a basic workflow that is manually triggered
 
 name: Recategorize labeled discussions
+permissions:
+  contents: read
+  discussions: write
 
 # Controls when the action will run. Workflow runs when manually triggered using the UI
 # or API.


### PR DESCRIPTION
Potential fix for [https://github.com/roseteromeo56/community/security/code-scanning/7](https://github.com/roseteromeo56/community/security/code-scanning/7)

To fix the issue, we will add a `permissions` block at the workflow level (root) to define the least privileges required for the workflow. Based on the operations performed in the workflow, the following permissions are necessary:
- `contents: read` to read repository contents if needed.
- `discussions: write` to move discussions to a new category.

This ensures that the workflow has only the permissions it needs and adheres to the principle of least privilege.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
