### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/remove-governed-labels-on-create.yml
+++ b/.github/workflows/remove-governed-labels-on-create.yml
@@ -5,6 +5,10 @@ on:
   discussion:
     types: [created]
 
+permissions:
+  contents: read
+  discussions: write
+
 jobs:
   check_labels:
     name: Check labels


### PR DESCRIPTION
Potential fix for [https://github.com/roseteromeo56/community/security/code-scanning/6](https://github.com/roseteromeo56/community/security/code-scanning/6)

To fix the issue, we will add a `permissions` block at the workflow level to explicitly define the minimal permissions required for the `GITHUB_TOKEN`. Based on the workflow's functionality:
- `contents: read` is needed to fetch repository information.
- `discussions: write` is required to remove labels from discussions.

The `permissions` block will be added at the root level of the workflow to apply to all jobs.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
