### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/label-templated-discussions.yml
+++ b/.github/workflows/label-templated-discussions.yml
@@ -4,6 +4,10 @@ on:
   discussion:
     types: [created]
 
+permissions:
+  contents: read
+  discussions: write
+
 jobs:
   label-templated-discussion:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/roseteromeo56/community/security/code-scanning/5](https://github.com/roseteromeo56/community/security/code-scanning/5)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will specify the minimal permissions required for the workflow to function correctly. Based on the operations performed in the workflow, the following permissions are needed:
- `contents: read` to allow the workflow to access repository contents.
- `discussions: read` to fetch discussion data.
- `discussions: write` to label discussions.

The `permissions` block will be added at the top level of the workflow, ensuring it applies to all jobs in the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
