### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/generator-generic-ossf-slsa3-publish.yml
+++ b/.github/workflows/generator-generic-ossf-slsa3-publish.yml
@@ -19,6 +19,8 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     outputs:
       digests: ${{ steps.hash.outputs.digests }}
 


### PR DESCRIPTION
Potential fix for [https://github.com/roseteromeo56/community/security/code-scanning/4](https://github.com/roseteromeo56/community/security/code-scanning/4)

To fix the issue, we will add a `permissions` block to the `build` job. Since the `build` job only involves checking out the repository and running commands to generate artifacts, it does not require any write permissions. The minimal permissions required are `contents: read`. This change ensures that the `build` job operates with the least privilege necessary.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
