### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/issue_projects_labeler.yml
+++ b/.github/workflows/issue_projects_labeler.yml
@@ -4,6 +4,11 @@ on:
   discussion:
     types: [created]
 
+permissions:
+  contents: read
+  discussions: write
+  issues: write
+
 jobs:
   label-templated-discussion:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/roseteromeo56/community/security/code-scanning/3](https://github.com/roseteromeo56/community/security/code-scanning/3)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the minimal permissions required for the workflow to function correctly. Based on the workflow's operations, the following permissions are likely needed:
- `contents: read` to access repository contents.
- `discussions: read` to fetch discussion data.
- `discussions: write` to label discussions.
- `repository-projects: read` to fetch project-related data (if applicable).
- `issues: read` and `issues: write` to interact with issue labels.

The `permissions` block should be added at the root level of the workflow to apply to all jobs.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
