### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/copilot_labeller.yml
+++ b/.github/workflows/copilot_labeller.yml
@@ -1,5 +1,9 @@
 name: Copilot Templated Discussions
 
+permissions:
+  contents: read
+  discussions: write
+
 on:
   discussion:
     types: [created]


### PR DESCRIPTION
Potential fix for [https://github.com/roseteromeo56/community/security/code-scanning/2](https://github.com/roseteromeo56/community/security/code-scanning/2)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will specify the minimal permissions required for the workflow to function correctly. Based on the workflow's actions, the following permissions are needed:
- `contents: read` to allow the workflow to access repository contents.
- `discussions: read` to fetch discussion data.
- `discussions: write` to label discussions.

The `permissions` block will be added at the top level of the workflow, ensuring that all jobs inherit these permissions unless overridden.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
