### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/Accessibility-Labeler.yml
+++ b/.github/workflows/Accessibility-Labeler.yml
@@ -4,6 +4,10 @@ on:
   discussion:
     types: [created]
 
+permissions:
+  contents: read
+  discussions: write
+
 jobs:
   label-templated-discussion:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/roseteromeo56/community/security/code-scanning/1](https://github.com/roseteromeo56/community/security/code-scanning/1)

To fix the issue, we need to add a `permissions` block at the workflow level to explicitly define the least privileges required for the workflow. Based on the operations in the workflow, the following permissions are necessary:
- `contents: read` for accessing repository contents.
- `discussions: read` for reading discussion data.
- `discussions: write` for adding labels to discussions.

The `permissions` block should be added at the root level of the workflow file to apply to all jobs.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
